### PR TITLE
Unexpected constructor-based initialization of nested @ConfigurationProperties leads to inconsistent behavior #25368

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -260,6 +260,14 @@ class ConfigurationPropertiesBinder {
 			return MergedAnnotations.from(target).isPresent(ConfigurationProperties.class);
 		}
 
+		/**
+		 * Iterates over the nested classes till top level class is found or a class with
+		 * {@link ConfigurationProperties} is found.
+		 *
+		 * @param target
+		 * @return {@link Boolean TRUE} When {@link ConfigurationProperties} annotaion is found.
+		 *	{@link Boolean FALSE} When {@link ConfigurationProperties} annotaion is not found.
+		 */
 		private boolean isNestedClassOfConfigurationProperty(final Class<?> target){
 			Class<?> enclosingClass = target.getEnclosingClass();
 			while(enclosingClass != null){

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -113,7 +113,7 @@ class ConfigurationPropertiesBinder {
 	private <T> BindHandler getBindHandler(Bindable<T> target, ConfigurationProperties annotation) {
 		List<Validator> validators = getValidators(target);
 		BindHandler handler = getHandler();
-		handler = new ConfigurationPropertiesBindHander(handler);
+		handler = new ConfigurationPropertiesBindHandler(handler);
 		if (annotation.ignoreInvalidFields()) {
 			handler = new IgnoreErrorsBindHandler(handler);
 		}
@@ -240,9 +240,9 @@ class ConfigurationPropertiesBinder {
 	 * {@link BindHandler} to deal with
 	 * {@link ConfigurationProperties @ConfigurationProperties} concerns.
 	 */
-	private static class ConfigurationPropertiesBindHander extends AbstractBindHandler {
+	private static class ConfigurationPropertiesBindHandler extends AbstractBindHandler {
 
-		ConfigurationPropertiesBindHander(BindHandler handler) {
+		ConfigurationPropertiesBindHandler(BindHandler handler) {
 			super(handler);
 		}
 
@@ -252,8 +252,23 @@ class ConfigurationPropertiesBinder {
 					? target.withBindRestrictions(BindRestriction.NO_DIRECT_PROPERTY) : target;
 		}
 
-		private boolean isConfigurationProperties(Class<?> target) {
-			return target != null && MergedAnnotations.from(target).isPresent(ConfigurationProperties.class);
+		private boolean isConfigurationProperties(final Class<?> target) {
+			return target != null && (hasConfigurationProperty(target) || isNestedClassOfConfigurationProperty(target));
+		}
+
+		private boolean hasConfigurationProperty(final Class<?> target){
+			return MergedAnnotations.from(target).isPresent(ConfigurationProperties.class);
+		}
+
+		private boolean isNestedClassOfConfigurationProperty(final Class<?> target){
+			Class<?> enclosingClass = target.getEnclosingClass();
+			while(enclosingClass != null){
+				if(hasConfigurationProperty(enclosingClass)){
+					return Boolean.TRUE;
+				}
+				enclosingClass = enclosingClass.getEnclosingClass();
+			}
+			return Boolean.FALSE;
 		}
 
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -256,22 +256,22 @@ class ConfigurationPropertiesBinder {
 			return target != null && (hasConfigurationProperty(target) || isNestedClassOfConfigurationProperty(target));
 		}
 
-		private boolean hasConfigurationProperty(final Class<?> target){
+		private boolean hasConfigurationProperty(final Class<?> target) {
 			return MergedAnnotations.from(target).isPresent(ConfigurationProperties.class);
 		}
 
 		/**
 		 * Iterates over the nested classes till top level class is found or a class with
 		 * {@link ConfigurationProperties} is found.
-		 *
-		 * @param target
-		 * @return {@link Boolean TRUE} When {@link ConfigurationProperties} annotaion is found.
-		 *	{@link Boolean FALSE} When {@link ConfigurationProperties} annotaion is not found.
+		 * @param target the nested class
+		 * @return
+		 * {@link Boolean TRUE} When {@link ConfigurationProperties} annotation is found.
+		 * {@link Boolean FALSE} When {@link ConfigurationProperties} annotation is not found.
 		 */
-		private boolean isNestedClassOfConfigurationProperty(final Class<?> target){
+		private boolean isNestedClassOfConfigurationProperty(final Class<?> target) {
 			Class<?> enclosingClass = target.getEnclosingClass();
-			while(enclosingClass != null){
-				if(hasConfigurationProperty(enclosingClass)){
+			while (enclosingClass != null) {
+				if (hasConfigurationProperty(enclosingClass)) {
 					return Boolean.TRUE;
 				}
 				enclosingClass = enclosingClass.getEnclosingClass();

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -1055,10 +1055,16 @@ class ConfigurationPropertiesTests {
 		Map<String, Object> source = new HashMap<>();
 		source.put("test", "bar");
 		source.put("test.a", "baz");
+		source.put("test.bar", "xyz");
+		source.put("test.bar.baz", "bar");
+		source.put("test.bar.foo", "x");
+		source.put("test.bar.foo.a", "foo");
 		sources.addLast(new MapPropertySource("test", source));
 		load(WithPublicStringConstructorPropertiesConfiguration.class);
 		WithPublicStringConstructorProperties bean = this.context.getBean(WithPublicStringConstructorProperties.class);
 		assertThat(bean.getA()).isEqualTo("baz");
+		assertThat(bean.getBar().getBaz()).isEqualTo("bar");
+		assertThat(bean.getBar().getFoo().getA()).isEqualTo("foo");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/WithPublicStringConstructorProperties.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/WithPublicStringConstructorProperties.java
@@ -18,14 +18,17 @@ package org.springframework.boot.context.properties;
 
 /**
  * A {@link ConfigurationProperties @ConfigurationProperties} with an additional
- * single-arg public constructor. Used in {@link ConfigurationPropertiesTests}.
+ * single-arg public constructor, along with layered inner classes.
+ *Used in {@link ConfigurationPropertiesTests}.
  *
  * @author Madhura Bhave
+ * @author prasoonanand
  */
 @ConfigurationProperties(prefix = "test")
 public class WithPublicStringConstructorProperties {
 
 	private String a;
+	private Bar bar;
 
 	public WithPublicStringConstructorProperties() {
 	}
@@ -42,4 +45,60 @@ public class WithPublicStringConstructorProperties {
 		this.a = a;
 	}
 
+	public Bar getBar() {
+		return bar;
+	}
+
+	public void setBar(Bar bar) {
+		this.bar = bar;
+	}
+
+	static class Bar {
+
+		private String baz;
+		private Foo foo;
+
+		static class Foo {
+
+			private String a;
+
+			public Foo() {
+			}
+
+			public Foo(String a) {
+				this.a = a;
+			}
+
+			public String getA() {
+				return a;
+			}
+
+			public void setA(String a) {
+				this.a = a;
+			}
+		}
+
+		public Bar() {
+		}
+
+		public Bar(String baz) {
+			this.baz = baz;
+		}
+
+		public String getBaz() {
+			return baz;
+		}
+
+		public void setBaz(String baz) {
+			this.baz = baz;
+		}
+
+		public Foo getFoo() {
+			return foo;
+		}
+
+		public void setFoo(Foo foo) {
+			this.foo = foo;
+		}
+	}
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/WithPublicStringConstructorProperties.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/WithPublicStringConstructorProperties.java
@@ -28,6 +28,7 @@ package org.springframework.boot.context.properties;
 public class WithPublicStringConstructorProperties {
 
 	private String a;
+
 	private Bar bar;
 
 	public WithPublicStringConstructorProperties() {
@@ -46,19 +47,43 @@ public class WithPublicStringConstructorProperties {
 	}
 
 	public Bar getBar() {
-		return bar;
+		return this.bar;
 	}
 
 	public void setBar(Bar bar) {
 		this.bar = bar;
 	}
 
-	static class Bar {
+	public static class Bar {
 
 		private String baz;
+
 		private Foo foo;
 
-		static class Foo {
+		public Bar() {
+		}
+
+		public Bar(String baz) {
+			this.baz = baz;
+		}
+
+		public String getBaz() {
+			return this.baz;
+		}
+
+		public void setBaz(String baz) {
+			this.baz = baz;
+		}
+
+		public Foo getFoo() {
+			return this.foo;
+		}
+
+		public void setFoo(Foo foo) {
+			this.foo = foo;
+		}
+
+		public static class Foo {
 
 			private String a;
 
@@ -70,7 +95,7 @@ public class WithPublicStringConstructorProperties {
 			}
 
 			public String getA() {
-				return a;
+				return this.a;
 			}
 
 			public void setA(String a) {
@@ -78,27 +103,5 @@ public class WithPublicStringConstructorProperties {
 			}
 		}
 
-		public Bar() {
-		}
-
-		public Bar(String baz) {
-			this.baz = baz;
-		}
-
-		public String getBaz() {
-			return baz;
-		}
-
-		public void setBaz(String baz) {
-			this.baz = baz;
-		}
-
-		public Foo getFoo() {
-			return foo;
-		}
-
-		public void setFoo(Foo foo) {
-			this.foo = foo;
-		}
 	}
 }


### PR DESCRIPTION
ConfigurationProperties on a top level class having a nested class is having an inconsistent behaviour.
 Example file has been added as a test case file `WithPublicStringConstructorProperties`...

Resolution:
On ConfigurationPropertiesBindHandler, Using the check which adds the BindRestriction.NO_DIRECT_PROPERTY. 
Created a method to check whether the target class is a Nested class of top-level class or a class which has the annotation ConfigurationProperties.
Also corrected the typo of `ConfigurationPropertiesBindHandler`...